### PR TITLE
Added Mac OS defaults (10.10+)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,8 @@
     dest: '{{perforce_p4v_link_dir}}'
     state: link
 - name: ensure profile directory exists
+  become: yes
+  become_user: root
   file:
     path: /etc/profile.d
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,10 @@
     src: '{{perforce_p4v_install_dir}}'
     dest: '{{perforce_p4v_link_dir}}'
     state: link
+- name: ensure profile directory exists
+  file:
+    path: /etc/profile.d
+    state: directory
 - name: add to the default shell path
   become: yes
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
 - name: download p4v archive...
   become: yes
   become_user: root
+  when: ansible_facts['system'] == "Linux"
   get_url:
     url: '{{perforce_mirror}}/{{perforce_p4v.ver}}/{{perforce_distro}}/{{perforce_p4v.tgz}}'
     dest: /tmp/{{perforce_p4v_tgz}}
@@ -34,6 +35,7 @@
 - name: unarchive...
   become: yes
   become_user: root
+  when: ansible_facts['system'] == "Linux"
   unarchive:
     src: /tmp/{{perforce_p4v_tgz}}
     dest: '{{perforce_p4v_parent_install_dir}}'
@@ -41,6 +43,7 @@
 - name: link p4v...
   become: yes
   become_user: root
+  when: ansible_facts['system'] == "Linux"
   file:
     src: '{{perforce_p4v_install_dir}}'
     dest: '{{perforce_p4v_link_dir}}'

--- a/vars/MacOSX.yml
+++ b/vars/MacOSX.yml
@@ -1,0 +1,6 @@
+---
+# vars for MacOSX
+perforce_distro: bin.macosx1010x86_64
+perforce_p4: 
+  ver: r19.1
+  checksum: 082f4000f60899fa0d676bef449680b88f081f215685e5d2d4ffc5f4c3f7aec2

--- a/vars/MacOSX.yml
+++ b/vars/MacOSX.yml
@@ -3,4 +3,4 @@
 perforce_distro: bin.macosx1010x86_64
 perforce_p4: 
   ver: r19.1
-  checksum: 082f4000f60899fa0d676bef449680b88f081f215685e5d2d4ffc5f4c3f7aec2
+  checksum: sha256:082f4000f60899fa0d676bef449680b88f081f215685e5d2d4ffc5f4c3f7aec2


### PR DESCRIPTION
I've added support for Mac OS (10.10+). I've set the defaults up in the vars/MacOSX.yml (vars/{ansible_os_family}.yml). 

Mac OS 10.10 is pretty old now.  If it's necessary to support earlier versions Perforce provide additional binaries. I think those should be handled by more specific variable files. 

I've tweaked the p4v tasks so they only run if the system is Linux. There aren't p4v tars/zips available for Mac OS or Windows. They're both supplied os-native installers. 

In addition Mac OS doesn't have an /etc/profile.d directory by default, but it supports it. On Linux the additional directory creation task should be a no-op. It is required on Mac OS though. 